### PR TITLE
Added ZlpFileInfo.OpenCreate() for consistency with File.Create()

### DIFF
--- a/Source/Runtime/ZlpFileInfo.cs
+++ b/Source/Runtime/ZlpFileInfo.cs
@@ -111,6 +111,17 @@
                 System.IO.FileAccess.ReadWrite);
         }
 
+        public System.IO.FileStream OpenCreate()
+        {
+            return new System.IO.FileStream(
+                ZlpIOHelper.CreateFileHandle(
+                    FullName,
+                    CreationDisposition.CreateAlways,
+                    FileAccess.GenericRead | FileAccess.GenericWrite,
+                    FileShare.Read | FileShare.Write),
+                System.IO.FileAccess.ReadWrite);
+        }
+
         public string ReadAllText() => ZlpIOHelper.ReadAllText(FullName);
 
         public string ReadAllText(Encoding encoding) => ZlpIOHelper.ReadAllText(FullName, encoding);


### PR DESCRIPTION
The .Net library has the method [`System.IO.File.Create()`](https://msdn.microsoft.com/en-us/library/system.io.file.create%28v=vs.110%29.aspx), which is like `File.OpenWrite()` (and hence `ZlpFileInfo.OpenWrite()`) except that if the file already exists, it is truncated to zero bytes. If you do something like this:

```C#
    using (FileStream fs = new ZlpFileInfo("Lalala.txt").OpenWrite())
    using (StreamWriter sw = new StreamWriter(fs))
    {
        sw.WriteLine("AAAAAAAAAAAAAAAAAAAA");
    }
    using (FileStream fs = new ZlpFileInfo("Lalala.txt").OpenWrite())
    using (StreamWriter sw = new StreamWriter(fs))
    {
        sw.WriteLine("BBBBB");
    }
```

... Lalala.txt has the following contents:

```
BBBBB
AAAAAAAAAAAAA
```

Whereas with my addition, if you replace OpenWrite() with OpenCreate(), Lalala.txt contains only `BBBBB`.